### PR TITLE
Download a torrent given its ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Usage
 
     $ kaizoku download "Game of Thrones s01e01"
     $ kaizoku d "Game of Thrones s01e01"
-    
+
 This will automatically:
 
 * Search for "Game of Thrones s01e01" on thepiratebay.se.
@@ -27,11 +27,15 @@ This will automatically:
 * Get the magnet link for the torrent and display it.
 * Open your torrent client and start the download.
 
+Alternatively, you can use an ID from the search below to download as well
+
+    $ kaizoku download -i 15496322
+
 #### Stream
 
     $ kaizoku stream "Game of Thrones s01e01"
     $ kaizoku st "Game of Thrones s01e01"
-    
+
 This will automatically:
 
 * Search for "Game of Thrones s01e01" on thepiratebay.se.
@@ -58,10 +62,10 @@ Displays a list of top torrents by category.
 
     $ kaizoku top movies
     $ kaizoku top tvshows
-    
+
     # Using aliases
     $ kaizoku t movies
-    
+
 To see a list of all categories:
 
     kaizoku cat
@@ -94,5 +98,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-  

--- a/app.js
+++ b/app.js
@@ -75,31 +75,60 @@ program
   .command('download [keywords]')
   .alias('d')
   .option("-c, --category <category>", 'The category to search in.')
+  .option("-i, --id <id>", 'The ID of a torrent to download.', parseInt)
   .description('Use this command to quickly download a torrent.')
   .action(function(keywords, options){
-    if (!keywords) {
-      console.log('Error: keywords missing');
-      program.help();
+    var torrentId = null;
+
+    // Only check if there are keywords to search if there is no ID
+    if (!options.id) {
+      if (!keywords) {
+        console.log('Error: keywords missing');
+        program.help();
+      }
+    } else {
+      torrentId = options.id;
     }
 
     kaizoku.setURL(program.url);
-    kaizoku.search(keywords, options.category, function(torrents) {
-      // Get the magnet link for the first result.
-      // Assumming the first result has the most seeds.
-      var magnentLink = torrents[0].magnet;
 
-      // Display the top torrent.
-      console.log("Found: ");
-      console.log(torrents[0].title);
+    if (torrentId) {
+      kaizoku.magnet(torrentId, function(torrent) {
+        // Get the magnet link for the first result.
+        // Assumming the first result has the most seeds.
+        var magnetLink = torrent.magnet;
 
-      // Display the magnet link.
-      console.log("");
-      console.log("Magnet link for top torrent:");
-      console.log(magnentLink);
+        // Display the top torrent.
+        console.log("Found: ");
+        console.log(torrent.title);
 
-      // Open the magnent link.
-      open(magnentLink);
-    });
+        // Display the magnet link.
+        console.log("");
+        console.log("Magnet link for torrent:");
+        console.log(magnetLink);
+
+        // Open the magnent link.
+        open(magnetLink);
+      });
+    } else {
+      kaizoku.search(keywords, options.category, function(torrents) {
+        // Get the magnet link for the first result.
+        // Assumming the first result has the most seeds.
+        var magnetLink = torrents[0].magnet;
+
+        // Display the top torrent.
+        console.log("Found: ");
+        console.log(torrents[0].title);
+
+        // Display the magnet link.
+        console.log("");
+        console.log("Magnet link for top torrent:");
+        console.log(magnetLink);
+
+        // Open the magnent link.
+        open(magnetLink);
+      });
+    }
   });
 
 /**
@@ -131,9 +160,9 @@ program
 
       // Get the magnet link for the first result.
       // Assumming the first result has the most seeds.
-      var magnentLink = torrents[0].magnet;
+      var magnetLink = torrents[0].magnet;
 
-      var engine = peerflix(magnentLink);
+      var engine = peerflix(magnetLink);
 
       engine.server.on('listening', function () {
         var myLink = 'http://localhost:' + engine.server.address().port + '/';

--- a/lib/kaizoku.js
+++ b/lib/kaizoku.js
@@ -15,7 +15,7 @@ var request = require('request')
   ;
 
 // URL
-exports.url = 'http://thepiratebay.se';
+exports.url = 'https://thepiratebay.org';
 
 /**
  * Search for torrents using the provided keywords.
@@ -39,6 +39,23 @@ exports.search = function(keywords, category, callback) {
       var torrents = exports.extractTorrents(body);
       if (callback) {
         callback(torrents);
+      }
+    }
+  })
+}
+
+/**
+ * Search for torrent using the provided ID.
+ */
+exports.magnet = function(id, callback) {
+  var searchURL = exports.buildQueryString('torrent', id);
+  request(searchURL, function (error, response, body) {
+    if (error) throw error;
+
+    if (!error && response.statusCode == 200) {
+      var magnetLink = exports.extractTorrentFromPage(body);
+      if (callback) {
+        callback(magnetLink);
       }
     }
   })
@@ -85,6 +102,7 @@ exports.extractTorrents = function(string) {
       // Parse string for data.
       var torrent = {};
       torrent.id = nextId++;
+      torrent.torrentId = $(this).find('td').eq(1).find('a').attr('href').split('/')[2];
       torrent.title = $(this).find('td').eq(1).find('a').text();
       torrent.magnet = $(this).find('td').eq(1).find('.detName').next('a').attr('href');
       torrent.details = $(this).find('td').eq(1).find('.detDesc').text();
@@ -100,10 +118,21 @@ exports.extractTorrents = function(string) {
 }
 
 /**
+ * Extracts a torrent magnet link from string using cheerio.
+ */
+exports.extractTorrentFromPage = function(string) {
+  $ = cheerio.load(string);
+  var torrent = {};
+  torrent.title = $("#title").text().trim()
+  torrent.magnet = $("#details").find('.download').find('a').attr('href')
+  return torrent;
+}
+
+/**
  * Logs torrents to the console in tabuler format.
  */
 exports.displayTorrents = function(torrents, categories, details) {
-  var columns = ['Id', 'Title', 'Seeders', 'Leachers']
+  var columns = ['Id', 'Torrent ID', 'Title', 'Seeders', 'Leachers']
 
   if (categories) columns.push('Category');
   if (details) columns.push('Details');
@@ -114,12 +143,10 @@ exports.displayTorrents = function(torrents, categories, details) {
 
   for (var i in torrents) {
     var torrent = torrents[i];
-    var records = [torrent.id, torrent.title, torrent.seeders, torrent.leechers]
+    var records = [torrent.id, torrent.torrentId, torrent.title, torrent.seeders, torrent.leechers]
     if (categories) records.push(torrent.category + '/' + torrent.subcategory);
     if (details) records.push(torrent.details);
-    table.push(
-      records
-    );
+    table.push(records);
   }
   console.log(table.toString());
 }

--- a/package.json
+++ b/package.json
@@ -26,19 +26,19 @@
   },
   "homepage": "https://github.com/arshad/kaizoku",
   "dependencies": {
-    "commander": "~2.3.0",
-    "request": "~2.38.0",
-    "cheerio": "~0.17.0",
-    "querystring": "~0.2.0",
-    "cli-table": "~0.3.0",
-    "open": "0.0.5",
-    "peerflix": "0.32.4",
-    "windows-no-runnable": "0.0.6",
-    "get-json": "0.0.2",
-    "readline-sync": "1.4.6"
+    "cheerio": "^0.22.0",
+    "cli-table": "^0.3.1",
+    "commander": "^2.9.0",
+    "get-json": "^0.0.3",
+    "open": "^0.0.5",
+    "readline-sync": "^1.4.6",
+    "peerflix": "^0.36.1",
+    "querystring": "^0.2.0",
+    "request": "^2.79.0",
+    "windows-no-runnable": "^0.0.6"
   },
   "devDependencies": {
-    "chai": "~1.9.1",
-    "mocha": "~1.21.0"
+    "chai": "^3.5.0",
+    "mocha": "^3.2.0"
   }
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -5,7 +5,7 @@ var chai = require('chai')
 
 describe('Kaizoku', function(){
   // Test search.
-  describe('#search("Game of Thrones)', function() {
+  describe('#search("Game of Thrones")', function() {
     it('should return an array of torrents', function() {
       kaizoku.search("Game of Thrones", function(torrents) {
         chai.expect(torrents).to.not.be.empty();
@@ -18,6 +18,15 @@ describe('Kaizoku', function(){
     it('should return an empty array', function() {
       kaizoku.search("lipsum dolor", function(torrents) {
         chai.expect(torrents).to.be.empty();
+      });
+    });
+  });
+
+  // Test torrent id lookup.
+  describe('#magnet(15496322)', function() {
+    it('should return a single torrent', function() {
+      kaizoku.magnet(15496322, function(torrent) {
+        chai.expect(torrent).to.not.be.empty();
       });
     });
   });


### PR DESCRIPTION
- Firstly upgraded a bunch of dependencies and tested to make sure nothing broke
- Added the ID of the torrent to the output table when searching
- Added ability to pass `-i, --id` flag to `kaizoku download`. Example: `kaizoku download --id 12345` will download the torrent given the magnet link at that torrent's page
- Added a test for this